### PR TITLE
Add support for PHP

### DIFF
--- a/src/language-definitions.json
+++ b/src/language-definitions.json
@@ -1,4 +1,10 @@
 {
+  "php": {
+    "quotes": ["'", "\""],
+    "brackets": ["()", "[]", "{}"],
+    "string_tokens": ["string","single-quoted-string","double-quoted-string"],
+    "bracket_tokens": ["punctuation"]
+  },
   "javascript": {
     "quotes": ["'", "\"", "`"],
     "brackets": ["()", "[]", "{}"],


### PR DESCRIPTION
Should fix #24

Can't seem to be able to support backticks which are occasionally used inside of SQL query strings, as these are unsupported by the prism.js tokenizer. It's probably for the best anyway, as trying to handle tokens inside tokens would probably be messy. For those edge cases you were still be able to use `Replace quotes with` until I removed the backtick option. At least swap works now.