### PR TITLE
Feat/context menu

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--enable-proposed-api"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+    },
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -141,6 +141,12 @@
         },
         {
           "command": "bracketeer.removeBrackets"
+        },
+        {
+          "command": "bracketeer.selectBracketContent"
+        },
+        {
+          "command": "bracketeer.swapBrackets"
         }
       ],
       "bracketeer.quotes": [
@@ -149,6 +155,12 @@
         },
         {
           "command": "bracketeer.removeQuotes"
+        },
+        {
+          "command": "bracketeer.selectQuotesContent"
+        },
+        {
+          "command": "bracketeer.swapQuotes"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -121,6 +121,46 @@
         "title": "Select quotes content",
         "category": "Bracketeer"
       }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "submenu": "bracketeer.brackets",
+          "group": "y_bracketeer",
+          "when": "editorIsOpen"
+        },
+        {
+          "submenu": "bracketeer.quotes",
+          "group": "y_bracketeer",
+          "when": "editorIsOpen"
+        }
+      ],
+      "bracketeer.brackets": [
+        {
+          "command": "bracketeer.changeBracketsTo"
+        },
+        {
+          "command": "bracketeer.removeBrackets"
+        }
+      ],
+      "bracketeer.quotes": [
+        {
+          "command": "bracketeer.changeQuotesTo"
+        },
+        {
+          "command": "bracketeer.removeQuotes"
+        }
+      ]
+    },
+    "submenus": [
+      {
+        "id": "bracketeer.brackets",
+        "label": "Bracketeer Brackets"
+      },
+      {
+        "id": "bracketeer.quotes",
+        "label": "Bracketeer Quotes"
+      }
     ]
   },
   "scripts": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2340296/95535614-81064a80-0a1b-11eb-8be6-380e2b8a270b.png)

Typing command in vscode is a bit inconvenient, so I add the commands to editor context menu. 

**Warning: submenu config is only available in vscode above 1.50.0. So this change is not backward compatible.**